### PR TITLE
Add function to recalculate the PIO SM clock

### DIFF
--- a/src/NeoPixelConnect.cpp
+++ b/src/NeoPixelConnect.cpp
@@ -139,3 +139,10 @@ void NeoPixelConnect::putPixel(uint32_t pixel_grb) {
     pio_sm_put_blocking(this->pixelPio, this->pixelSm,
                         pixel_grb << 8u);
 }
+
+/// @brief recalculate the clock to match a new CPU clock
+void NeoPixelConnect::recalculateClock(){
+    int cycles_per_bit = ws2812_T1 + ws2812_T2 + ws2812_T3;
+    float div = clock_get_hz(clk_sys) / (800000.0f * cycles_per_bit);
+    pio_sm_set_clkdiv(this->pixelPio, this->pixelSm, div);
+}

--- a/src/NeoPixelConnect.h
+++ b/src/NeoPixelConnect.h
@@ -91,6 +91,9 @@ public:
     /// @param pixel_grb: rgb represented as a 32 bit value
     void putPixel(uint32_t pixel_grb); //{
 
+    /// @brief recalculate the clock to match a new CPU clock
+    void recalculateClock();
+
 
 private:
     // pio - 0 or 1


### PR DESCRIPTION
If you change the CPU's clock speed (which the PIO SM is tied to), you can no longer refresh the LEDs until you go back to the original speed. This PR adds a function to recalculate the state machine's clock (called `NeoPixelConnect::recalculateClock()`) that you can call after you have set a new CPU speed. 